### PR TITLE
[BUGFIX] Corrige la connexion avec des caractères spéciaux

### DIFF
--- a/script.js
+++ b/script.js
@@ -54,7 +54,11 @@ async function getToken(baseUrl, { email, password }) {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: `grant_type=password&username=${email}&password=${password}`,
+    body: new URLSearchParams({
+      username: email,
+      password,
+      'grant_type': 'password'
+    }),
   });
   if (response.status === 401) {
     throw new Error('Vérifier vos informations de connexion');


### PR DESCRIPTION
Les champs username et password n'étaient pas correctement encodé, ce qui pouvait casser la connexion.